### PR TITLE
Fix invalid zipcodes

### DIFF
--- a/lib/pmf_nfpse_generator.rb
+++ b/lib/pmf_nfpse_generator.rb
@@ -52,9 +52,14 @@ class PmfNfpseGenerator
     I18n.default_locale = 'pt-BR'
   end
 
+  def city_info
+    return @city_info if @city_info
+    self.city_info = get_city_info(zipcode.try(:gsub, ".", ""), state, city)
+  end
+
   # {"city"=>"Curitiba", "state"=>"PR", "city_ibge_code"=>"4106902", "source"=>"csv"}
   def to_xml
-    return nil unless self.valid?
+    return nil unless valid?
 
     date = billing_date.try(:to_datetime).try(:strftime, '%Y-%m-%d')
 

--- a/lib/pmf_nfpse_generator.rb
+++ b/lib/pmf_nfpse_generator.rb
@@ -52,14 +52,9 @@ class PmfNfpseGenerator
     I18n.default_locale = 'pt-BR'
   end
 
-  def city_info
-    return @city_info if @city_info
-    self.city_info = get_city_info(zipcode.try(:gsub, ".", ""), state, city)
-  end
-
   # {"city"=>"Curitiba", "state"=>"PR", "city_ibge_code"=>"4106902", "source"=>"csv"}
   def to_xml
-    return nil unless valid?
+    return nil if !valid? || !city_info
 
     date = billing_date.try(:to_datetime).try(:strftime, '%Y-%m-%d')
 

--- a/lib/pmf_nfpse_generator.rb
+++ b/lib/pmf_nfpse_generator.rb
@@ -11,12 +11,11 @@ class PmfNfpseGenerator
 
   attr_accessor :config
   attr_accessor :cities
-  attr_accessor :cpf_cnpj, :name, :address, :zipcode, :state, :city, :email, :cfps, :billing_date, :items, :extra_info, :csrf, :irrf
+  attr_accessor :cpf_cnpj, :name, :address, :zipcode, :state, :city, :email, :cfps, :billing_date, :items, :extra_info, :csrf, :irrf, :city_info
 
   validates_presence_of :cpf_cnpj, :name, :address, :zipcode, :state, :city, :email, :billing_date, :items
   validate :billing_date_cannot_be_in_the_future
   validate :cpf_cnpj_format
-  validate :zipcode_in_postmon_api
 
   def initialize(attrs = {})
     # {:cpf_cnpj=>"13.372.575/0001-87", :name=>"SOCIALBASE SOLUCOES EM TECNOLOGIA LTDA", :address=>"Rod SC 401", :city=>"Florianópolis", :zipcode=>"88030-000", :state=>"SC", :email=>"pedro.bachiega-22@resultadosdigitais.com.br", :cfps=>nil, :items=>[{:price=>919, :cnae_id=>"9178", :cnae_code=>"6203100", :cnae_desc=>"SERVIÇO DE LICENCIAMENTO DE PROGRAMA DE MARKETING DIGITAL - RD STATION", :cnae_aliquota=>0.02, :cst=>"0"}, {:price=>750, :cnae_id=>"9177", :cnae_code=>"6204000", :cnae_desc=>"CONSULTORIA EM TECNOLOGIA DA INFORMAÇÃO E MARKETING DIGITAL - RD STATION", :cnae_aliquota=>0.02, :cst=>"0"}], :extra_info=>nil}
@@ -37,6 +36,7 @@ class PmfNfpseGenerator
     self.irrf = attrs[:irrf]
 
     self.extra_info = attrs[:extra_info]
+    self.city_info = get_city_info(zipcode.try(:gsub, ".", ""), state, city) if valid?
   end
 
   def configure
@@ -56,7 +56,6 @@ class PmfNfpseGenerator
   def to_xml
     return nil unless self.valid?
 
-    city_info = get_city_info(zipcode.gsub(".",""), state, city)
     date = billing_date.try(:to_datetime).try(:strftime, '%Y-%m-%d')
 
     xml = Builder::XmlMarkup.new( :indent => 2 )
@@ -172,18 +171,35 @@ Conforme lei federal 12.741/2012 da transparência, total impostos pagos R$ #{ta
     cpf_cnpj.gsub(".", "").gsub("/", "").gsub("-", "").gsub("_", "").gsub(" ", "")
   end
 
-  def get_city_info(cep, state = "", cityname = "")
-    state.strip!
-    cityname.strip!
-    cityname = (cityname.downcase == "brasilia") ? "brasília" : cityname
-    cityname = (cityname.downcase == "sao paulo") ? "são paulo" : cityname
-
-    city_info = nil
-    city_info = get_cities[state.downcase][cityname.downcase] if get_cities[state.downcase]
-    if city_info
-      return { "city" => city_info["Nome_Município"], "state" => city_info["UF"], "city_ibge_code" => city_info["UF_MUNIC"], "source" => "csv" }
+  def get_city_info(zip, state = "", cityname = "")
+    if state && cityname
+      state.strip!
+      cityname.strip!
+      cityname = (cityname.downcase == "brasilia") ? "brasília" : cityname
+      cityname = (cityname.downcase == "sao paulo") ? "são paulo" : cityname
+      city_info = nil
+      city_info = get_cities[state.downcase][cityname.downcase] if get_cities[state.downcase]
+      if city_info
+        return { "city" => city_info["Nome_Município"], "state" => city_info["UF"], "city_ibge_code" => city_info["UF_MUNIC"], "source" => "csv" }
+      end
     end
-    response = HTTParty.get("http://api.postmon.com.br/v1/cep/#{cep}")
+
+    get_city_info_from_zip(zip)
+  end
+
+  def get_city_info_from_zip(zip)
+    response = HTTParty.get("http://api.postmon.com.br/v1/cep/#{zip}")
+    unless response.code == 200
+      errors.add(:zipcode, :invalid)
+      return nil
+    end
+
+    parsed_response = response.parsed_response
+    if parsed_response['cidade_info'].blank?
+      errors.add(:zipcode, :invalid)
+      return nil
+    end
+
     resp = response.parsed_response
     { "city" => resp["cidade"], "state" => resp["estado"], "city_ibge_code" => resp["cidade_info"]["codigo_ibge"], "source" => "postmon" }
   end
@@ -227,21 +243,8 @@ Conforme lei federal 12.741/2012 da transparência, total impostos pagos R$ #{ta
     end
   end
 
-  def zipcode_in_postmon_api
-    return unless zipcode.present?
-    return errors.add(:zipcode, :length) unless zipcode.size == 8
-    response = validate_zipcode_in_postmon_api(zipcode)
-    return errors.add(:zipcode, :invalid) unless response.code == 200
-    parsed_response = response.parsed_response
-    errors.add(:zipcode, :invalid) if parsed_response['cidade_info'].blank?
-  end
-
   def zipcode_strip(zip)
     return unless zip
     zip.delete('.').delete('/').delete('-').delete(' ')
-  end
-
-  def validate_zipcode_in_postmon_api(cep)
-    HTTParty.get("http://api.postmon.com.br/v1/cep/#{cep}")
   end
 end

--- a/lib/pmf_nfpse_generator.rb
+++ b/lib/pmf_nfpse_generator.rb
@@ -37,7 +37,7 @@ class PmfNfpseGenerator
     self.irrf = attrs[:irrf]
 
     self.extra_info = attrs[:extra_info]
-    self.city_info = get_city_info(zipcode.try(:gsub, ".", ""), state, city) if valid?
+    self.city_info = get_city_info(zipcode.try(:gsub, ".", ""), state, city)
   end
 
   def configure
@@ -55,7 +55,7 @@ class PmfNfpseGenerator
 
   # {"city"=>"Curitiba", "state"=>"PR", "city_ibge_code"=>"4106902", "source"=>"csv"}
   def to_xml
-    return nil if !valid? || !city_info
+    return nil unless valid?
 
     date = billing_date.try(:to_datetime).try(:strftime, '%Y-%m-%d')
 

--- a/spec/pmf_nfpse_generator_spec.rb
+++ b/spec/pmf_nfpse_generator_spec.rb
@@ -131,7 +131,7 @@ describe PmfNfpseGenerator do
          end
        end
 
-       context "invalid cpf_cnpj" do
+       context "invalid billing_date" do
          it do
            lib.billing_date = "#{1.day.from_now.day}/#{1.day.from_now.month}/#{1.day.from_now.year}"
            VCR.use_cassette('to_xml_invalid_cpf_cnpj') do

--- a/spec/pmf_nfpse_generator_spec.rb
+++ b/spec/pmf_nfpse_generator_spec.rb
@@ -10,9 +10,9 @@ describe PmfNfpseGenerator do
        cpf_cnpj: "00.000.000/0000-00",
        name: "name",
        address: "address",
-       city: "city",
+       city: "Florianópolis",
        zipcode: "88062365",
-       state: "sc",
+       state: "SC",
        email: "email",
        cfps: "cfps",
        cst: "cst",
@@ -47,66 +47,99 @@ describe PmfNfpseGenerator do
      end
 
      describe "validate" do
+       let(:invalid_lib) { PmfNfpseGenerator.new(invalid_attrs) }
 
-       let(:invalid_lib) { PmfNfpseGenerator.new }
+       context "without zipcode" do
+         let(:invalid_attrs) { attrs.merge(zipcode: nil) }
 
-       it "without zipcode" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:zipcode].size).to eq(1)
-       end
-
-       it "without cpf_cnpj" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:cpf_cnpj].size).to eq(1)
-       end
-
-       it "without state" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:state].size).to eq(1)
-       end
-
-       it "without city" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:city].size).to eq(1)
-       end
-
-       it "without billing_date" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:billing_date].size).to eq(1)
-       end
-
-       it "without email" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:email].size).to eq(1)
-       end
-
-       it "without name" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:name].size).to eq(1)
-       end
-
-       it "without address" do
-         expect(invalid_lib.to_xml).to be_falsey
-         expect(invalid_lib.errors[:address].size).to eq(1)
-       end
-
-       it "invalid cpf_cnpj" do
-         lib.cpf_cnpj = "000"
-         VCR.use_cassette('to_xml_invalid_cpf_cnpj') do
-           expect(lib.to_xml).to be_falsey
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:zipcode].size).to eq(1)
          end
-         expect(lib.errors[:cpf_cnpj].size).to eq(1)
        end
 
-       it "invalid cpf_cnpj" do
-         lib.billing_date = "#{1.day.from_now.day}/#{1.day.from_now.month}/#{1.day.from_now.year}"
-         VCR.use_cassette('to_xml_invalid_cpf_cnpj') do
-           expect(lib.to_xml).to be_falsey
+       context "without cpf_cnpj" do
+         let(:invalid_attrs) { attrs.merge(cpf_cnpj: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:cpf_cnpj].size).to eq(1)
          end
-         expect(lib.errors[:billing_date].size).to eq(1)
        end
 
+       context "without state" do
+         let(:invalid_attrs) { attrs.merge(state: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:state].size).to eq(1)
+         end
+       end
+
+       context "without city" do
+         let(:invalid_attrs) { attrs.merge(city: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:city].size).to eq(1)
+         end
+       end
+
+       context "without billing_date" do
+         let(:invalid_attrs) { attrs.merge(billing_date: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:billing_date].size).to eq(1)
+         end
+       end
+
+       context "without email" do
+         let(:invalid_attrs) { attrs.merge(email: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:email].size).to eq(1)
+         end
+       end
+
+       context "without name" do
+         let(:invalid_attrs) { attrs.merge(name: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:name].size).to eq(1)
+         end
+       end
+
+       context "without address" do
+         let(:invalid_attrs) { attrs.merge(address: nil) }
+
+         it do
+           expect(invalid_lib.to_xml).to be_falsey
+           expect(invalid_lib.errors[:address].size).to eq(1)
+         end
+       end
+
+       context "invalid cpf_cnpj" do
+         it do
+           lib.cpf_cnpj = "000"
+           VCR.use_cassette('to_xml_invalid_cpf_cnpj') do
+             expect(lib.to_xml).to be_falsey
+           end
+           expect(lib.errors[:cpf_cnpj].size).to eq(1)
+         end
+       end
+
+       context "invalid cpf_cnpj" do
+         it do
+           lib.billing_date = "#{1.day.from_now.day}/#{1.day.from_now.month}/#{1.day.from_now.year}"
+           VCR.use_cassette('to_xml_invalid_cpf_cnpj') do
+             expect(lib.to_xml).to be_falsey
+           end
+           expect(lib.errors[:billing_date].size).to eq(1)
+         end
+       end
      end
    end
-
 end


### PR DESCRIPTION
## Problema
Mesmo tendo o código da cidade no csv, a lib ainda fazia a validação do CEP. O problema disso é que o XML seria gerado mesmo com o CEP inválido e que a prefeitura aceitaria esse XML.

## Solucão
Tentar consumir do CSV já na inicialização, colocando erros caso não consiga consumir do csv ou do postmon.

## Pré-requisitos para testar
Criar um App Rails para testar o plugin
1 - rails new test_gem_pmf_nfpse_generator
2 - cd test_gem_pmf_nfpse_generator/
3 - nano Gemfile
4 - add 
```ruby
gem 'pmf_nfpse_generator', git: 'https://github.com/ResultadosDigitais/pmf_nfpse_generator.git', branch: 'fix_invalid_zipcodes'
```
5 - bundle install
6 - rails c

Script para gerar XML
```ruby
require 'pmf_nfpse_generator'
items = [{:price=>919, :cnae_id=>"9178", :cnae_code=>"6203100", :cnae_desc=>"SERVIÇO DE LICENCIAMENTO DE PROGRAMA DE MARKETING DIGITAL - RD STATION", :cnae_aliquota=>0.02, :cst=>"0"}]
attrs = {
  billing_date: Time.current,
  cpf_cnpj: "00.000.000/0000-00",
  name: "name",
  address: "address",
  city: city,
  zipcode: cep,
  state: "sc",
  email: "email",
  cfps: "cfps",
  cst: "cst",
  extra_info: "extra_info",
  csrf: 1,
  irrf: 1,
items: items
}
lib = PmfNfpseGenerator.new(attrs)
lib.configure do |config|
  config.TipoSistema = "1"
  config.Emissor_Identificacao = "X542H1"
  config.Emissor_AEDF = "578256"
  config.Emissor_TipoAedf = "NORMAL"
  config.Emissor_Cidade = "Florianópolis"
  config.Emissor_Estado = "SC"
  config.Impostos = { :pis => 0.0065, :cofins => 0.03, :iss => 0.02, :cprb => 0.02 };
end
lib.to_xml
```

## Cenários
### Primeiro Cenário
- **Dado** cenario criado nos pre-requisitos
- **Quando** abro o console, e executo o comando abaixo e depois o script dos pré-requisitos
```ruby
city = "city"
cep = "88062365"
```
- [x] **Então** é gerado o XML corretamente

### Segundo Cenário
- **Dado** cenario criado nos pre-requisitos
- **Quando** abro o console, e executo o comando abaixo e depois o script dos pré-requisitos
```ruby
city = "city"
cep = "99999999"
```
- [x] **Então** não é gerado o XML
- [x] **E** ao executar o comando abaixo, recebo a mensagem cep invalido
```ruby
lib.errors.messages
```

### Terceiro Cenário
- **Dado** cenario criado nos pre-requisitos
- **Quando** abro o console, e executo o comando abaixo e depois o script dos pré-requisitos
```ruby
city = "city"
cep = "999"
```
- [x] **Então** não é gerado o XML
- [x] **E** ao executar o comando abaixo, recebo a mensagem cep invalido
```ruby
lib.errors.messages
```

### Quarto Cenário
- **Dado** cenario criado nos pre-requisitos
- **Quando** abro o console, e executo o comando abaixo e depois o script dos pré-requisitos
```ruby
city = "Florianópolis"
cep = "999"
```
- [x] **Então** é gerado o XML